### PR TITLE
Ensure status descriptions are not over 140 characters

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -405,14 +405,14 @@ async function unhaltOpenPullRequests(client, context, inputs) {
         await unhaltPullRequest(client, context, inputs, pullRequest);
     });
 }
-async function haltPullRequest(client, context, inputs, pullRequest, message) {
+async function haltPullRequest(client, context, inputs, pullRequest, msg) {
     console.info(`Setting halted status for PR #${pullRequest.number}`);
     await githubApi.createCommitStatus(client, {
         ...context.repo,
         sha: pullRequest.head.sha,
         context: inputs.statusContext,
         state: "failure",
-        description: message.title,
+        description: message.toStatusDescription(msg),
         target_url: inputs.statusTargetUrl,
     });
 }
@@ -487,7 +487,7 @@ run();
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.toString = exports.fromContent = exports.wasOriginallyEmpty = void 0;
+exports.toString = exports.toStatusDescription = exports.fromContent = exports.wasOriginallyEmpty = void 0;
 const DEFAULT_TITLE = "Merges halted";
 function wasOriginallyEmpty(message) {
     return message.title === DEFAULT_TITLE;
@@ -517,6 +517,15 @@ function fromContent(contents) {
     }
 }
 exports.fromContent = fromContent;
+function toStatusDescription(message) {
+    const { title } = message;
+    const maxLength = 140;
+    if (title.length > maxLength) {
+        return `${title.slice(0, maxLength - 3)}...`;
+    }
+    return title;
+}
+exports.toStatusDescription = toStatusDescription;
 function toString(message) {
     return message.summary
         ? `${message.title}\n${message.summary}`

--- a/src/main.ts
+++ b/src/main.ts
@@ -160,7 +160,7 @@ async function haltPullRequest(
   context: Context,
   inputs: Inputs,
   pullRequest: PullRequest,
-  message: Message,
+  msg: Message,
 ): Promise<void> {
   console.info(`Setting halted status for PR #${pullRequest.number}`);
   await githubApi.createCommitStatus(client, {
@@ -168,7 +168,7 @@ async function haltPullRequest(
     sha: pullRequest.head.sha,
     context: inputs.statusContext,
     state: "failure",
-    description: message.title,
+    description: message.toStatusDescription(msg),
     target_url: inputs.statusTargetUrl,
   });
 }

--- a/src/message.test.ts
+++ b/src/message.test.ts
@@ -68,6 +68,25 @@ paragraph or two.
 `);
 });
 
+test("toStatusDescription short", () => {
+  const msg = message.fromContent("This is a message");
+
+  expect(message.toStatusDescription(msg)).toEqual(msg.title);
+});
+
+test("toStatusDescription long", () => {
+  const msg = message.fromContent(
+    "This is a super long message that is much longer than 140 characters and " +
+      "it just keeps going and why would anyone make a HALT file with a title " +
+      "this long?",
+  );
+  const description = message.toStatusDescription(msg);
+
+  expect(description.length).toEqual(140);
+  expect(description.slice(0, 20)).toEqual("This is a super long");
+  expect(description.slice(-20)).toEqual(" HALT file with a...");
+});
+
 test("toString preserves content", () => {
   const single = "We're down";
   const multi = `We're down

--- a/src/message.ts
+++ b/src/message.ts
@@ -35,6 +35,17 @@ export function fromContent(contents: string): Message {
   }
 }
 
+export function toStatusDescription(message: Message): string {
+  const { title } = message;
+  const maxLength = 140;
+
+  if (title.length > maxLength) {
+    return `${title.slice(0, maxLength - 3)}...`;
+  }
+
+  return title;
+}
+
 export function toString(message: Message): string {
   return message.summary
     ? `${message.title}\n${message.summary}`


### PR DESCRIPTION
It may not be clear that the `HALT` file contents are meant to be
formatted like a commit or PR, with a reasonable-length title and
optional body below.

When folks write things as one long line, that is interpreted as title
and used as the status description, and we get:

    Setting halted status for PR #37776
    Error: HttpError: Validation Failed: {"resource":"Status","code":"custom","field":"description","message":"description is too long (maximum is 140 characters)"}

We can just truncate to avoid it.