### PR TITLE
feat: add ignore-labels input

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ jobs:
         with: # all optional, defaults shown
           default-branch: main
           halt-file: .github/HALT
+          ignore-labels: null
           status-context: halt
           status-target-url: null
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -62,6 +63,23 @@ line will become the PR status description. The remaining lines, if there are
 any, will be added as a [Workflow Job Summary][workflow-job-summary].
 
 [workflow-job-summary]: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary
+
+## Ignore Labels
+
+Sometimes you may open a PR that _might_ fix the reason you are halted, or maybe
+it is part of a fix. Therefore, you don't want to remove the halt file as part
+of this PR, but you do need that PR to not be halted.
+
+To support such cases, you can configure `ignore-labels`:
+
+```yaml
+ignore-labels: |
+  HotFix
+  BypassHalt
+  FixesHalt
+```
+
+Then apply one of these labels to allow PRs through while halted.
 
 ## Inputs & Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
   halt-file:
     description: "The path to the file used to halt"
-    require: true
+    required: true
     default: ".github/HALT"
   status-context:
     description: "The context used when commit-statuses are created"

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
     description: "The path to the file used to halt"
     required: true
     default: ".github/HALT"
+  ignore-labels:
+    description: "Labels, one per line, that cause a PR to not be halted."
+    required: false
   status-context:
     description: "The context used when commit-statuses are created"
     required: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -69330,6 +69330,7 @@ function getInputs() {
         defaultBranch: core.getInput("default-branch", { required: true }),
         haltBranch: core.getInput("halt-branch", { required: false }),
         haltFile: core.getInput("halt-file", { required: true }),
+        ignoreLabels: core.getMultilineInput("ignore-labels", { required: false }),
         statusContext: core.getInput("status-context", { required: true }),
         statusTargetUrl: core.getInput("status-target-url", { required: false }),
         slackWebhook: core.getInput("slack-webhook", { required: false }),
@@ -69397,6 +69398,7 @@ async function run() {
         const inputs = getInputs();
         core.info(`defaultBranch: ${inputs.defaultBranch}`);
         core.info(`haltFile: ${inputs.haltFile}`);
+        core.info(`ignoreLabels: ${inputs.ignoreLabels.join(", ")}`);
         core.info(`statusContext: ${inputs.statusContext}`);
         core.info(`statusTargetUrl: ${inputs.statusTargetUrl}`);
         core.info(`githubToken: ${inputs.githubToken}`);
@@ -69407,7 +69409,7 @@ async function run() {
         }
         const pullRequest = github.context.payload.pull_request;
         if (pullRequest) {
-            return await handlePullRequest(inputs, client, pullRequest);
+            return await handlePullRequest(inputs, client, pullRequest, inputs.ignoreLabels);
         }
         const payload = Object.keys(github.context.payload);
         const details = [
@@ -69451,7 +69453,13 @@ async function handleMain(inputs, client) {
         core.endGroup();
     }
 }
-async function handlePullRequest(inputs, client, pullRequest) {
+async function handlePullRequest(inputs, client, pullRequest, ignoreLabels) {
+    pullRequest.labels.forEach((l) => {
+        if (ignoreLabels.includes(l.name)) {
+            core.info(`Ignoring Pull Request because label ${l.name} is in ignore-labels`);
+            return;
+        }
+    });
     const haltBranch = inputs.haltBranch || inputs.defaultBranch;
     const haltFile = await getRepositoryContent(client, {
         ...github.context.repo,

--- a/dist/index.js
+++ b/dist/index.js
@@ -69409,7 +69409,7 @@ async function run() {
         }
         const pullRequest = github.context.payload.pull_request;
         if (pullRequest) {
-            return await handlePullRequest(inputs, client, pullRequest, inputs.ignoreLabels);
+            return await handlePullRequest(inputs, client, pullRequest);
         }
         const payload = Object.keys(github.context.payload);
         const details = [
@@ -69453,11 +69453,11 @@ async function handleMain(inputs, client) {
         core.endGroup();
     }
 }
-async function handlePullRequest(inputs, client, pullRequest, ignoreLabels) {
-    pullRequest.labels.forEach((l) => {
-        if (ignoreLabels.includes(l.name)) {
-            core.info(`Ignoring Pull Request because label ${l.name} is in ignore-labels`);
-            return;
+async function handlePullRequest(inputs, client, pullRequest) {
+    await pullRequest.labels.forEach(async (l) => {
+        if (inputs.ignoreLabels.includes(l.name)) {
+            core.info(`PR has label ${l.name} in ignore-labels`);
+            return await unhaltPullRequest(client, github.context, inputs, pullRequest);
         }
     });
     const haltBranch = inputs.haltBranch || inputs.defaultBranch;

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -4,6 +4,7 @@ export type Inputs = {
   defaultBranch: string;
   haltBranch: string | undefined;
   haltFile: string;
+  ignoreLabels: string[];
   statusContext: string;
   statusTargetUrl: string | undefined;
   slackWebhook: string | undefined;
@@ -16,6 +17,7 @@ export function getInputs(): Inputs {
     defaultBranch: core.getInput("default-branch", { required: true }),
     haltBranch: core.getInput("halt-branch", { required: false }),
     haltFile: core.getInput("halt-file", { required: true }),
+    ignoreLabels: core.getMultilineInput("ignore-labels", { required: false }),
     statusContext: core.getInput("status-context", { required: true }),
     statusTargetUrl: core.getInput("status-target-url", { required: false }),
     slackWebhook: core.getInput("slack-webhook", { required: false }),

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,15 +4,15 @@ import * as github from "@actions/github";
 
 import type { IncomingWebhookSendArguments } from "@slack/webhook";
 import { IncomingWebhook } from "@slack/webhook";
-import { getChangesInPush, getChangesInPullRequest } from "./changes.js"
-import type { Context } from "./context.js"
-import type { GitHubClient } from "./github-api.js"
-import * as githubApi from "./github-api.js"
-import type { Inputs } from "./inputs.js"
-import { getInputs } from "./inputs.js"
-import type { PullRequest } from "./pull-request.js"
-import type { Message } from "./message.js"
-import * as message from "./message.js"
+import { getChangesInPush, getChangesInPullRequest } from "./changes.js";
+import type { Context } from "./context.js";
+import type { GitHubClient } from "./github-api.js";
+import * as githubApi from "./github-api.js";
+import type { Inputs } from "./inputs.js";
+import { getInputs } from "./inputs.js";
+import type { PullRequest } from "./pull-request.js";
+import type { Message } from "./message.js";
+import * as message from "./message.js";
 
 async function run() {
   try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import type { GitHubClient } from "./github-api.js";
 import * as githubApi from "./github-api.js";
 import type { Inputs } from "./inputs.js";
 import { getInputs } from "./inputs.js";
-import type { PullRequest } from "./pull-request.js";
+import type { PullRequest, Label } from "./pull-request.js";
 import type { Message } from "./message.js";
 import * as message from "./message.js";
 
@@ -20,6 +20,7 @@ async function run() {
     const inputs = getInputs();
     core.info(`defaultBranch: ${inputs.defaultBranch}`);
     core.info(`haltFile: ${inputs.haltFile}`);
+    core.info(`ignoreLabels: ${inputs.ignoreLabels.join(", ")}`);
     core.info(`statusContext: ${inputs.statusContext}`);
     core.info(`statusTargetUrl: ${inputs.statusTargetUrl}`);
     core.info(`githubToken: ${inputs.githubToken}`);
@@ -34,7 +35,12 @@ async function run() {
     const pullRequest = github.context.payload.pull_request as PullRequest;
 
     if (pullRequest) {
-      return await handlePullRequest(inputs, client, pullRequest);
+      return await handlePullRequest(
+        inputs,
+        client,
+        pullRequest,
+        inputs.ignoreLabels,
+      );
     }
 
     const payload = Object.keys(github.context.payload);
@@ -86,7 +92,17 @@ async function handlePullRequest(
   inputs: Inputs,
   client: GitHubClient,
   pullRequest: PullRequest,
+  ignoreLabels: string[],
 ): Promise<void> {
+  pullRequest.labels.forEach((l: Label) => {
+    if (ignoreLabels.includes(l.name)) {
+      core.info(
+        `Ignoring Pull Request because label ${l.name} is in ignore-labels`,
+      );
+      return;
+    }
+  });
+
   const haltBranch = inputs.haltBranch || inputs.defaultBranch;
   const haltFile = await githubApi.getRepositoryContent(client, {
     ...github.context.repo,

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,12 +88,15 @@ async function handlePullRequest(
   client: GitHubClient,
   pullRequest: PullRequest,
 ): Promise<void> {
-  pullRequest.labels.forEach((l: Label) => {
+  await pullRequest.labels.forEach(async (l: Label) => {
     if (inputs.ignoreLabels.includes(l.name)) {
-      core.info(
-        `Ignoring Pull Request because label ${l.name} is in ignore-labels`,
+      core.info(`PR has label ${l.name} in ignore-labels`);
+      return await unhaltPullRequest(
+        client,
+        github.context,
+        inputs,
+        pullRequest,
       );
-      return;
     }
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,12 +35,7 @@ async function run() {
     const pullRequest = github.context.payload.pull_request as PullRequest;
 
     if (pullRequest) {
-      return await handlePullRequest(
-        inputs,
-        client,
-        pullRequest,
-        inputs.ignoreLabels,
-      );
+      return await handlePullRequest(inputs, client, pullRequest);
     }
 
     const payload = Object.keys(github.context.payload);
@@ -92,10 +87,9 @@ async function handlePullRequest(
   inputs: Inputs,
   client: GitHubClient,
   pullRequest: PullRequest,
-  ignoreLabels: string[],
 ): Promise<void> {
   pullRequest.labels.forEach((l: Label) => {
-    if (ignoreLabels.includes(l.name)) {
+    if (inputs.ignoreLabels.includes(l.name)) {
       core.info(
         `Ignoring Pull Request because label ${l.name} is in ignore-labels`,
       );

--- a/src/pull-request.ts
+++ b/src/pull-request.ts
@@ -3,4 +3,9 @@ export type PullRequest = {
   head: {
     sha: string;
   };
+  labels: Label[];
+};
+
+export type Label = {
+  name: string;
 };


### PR DESCRIPTION
If a PR has a label specified here, it will not be halted. This can be
used to open PRs that *might* fix whatever issue is causing the halt, so
you want them be able to merge, but you don't want to pro-actively
remove the halt file as part of them.
